### PR TITLE
[-] MO: paypal confirmation page SHOULD obey SSL settings

### DIFF
--- a/controllers/front/submit.php
+++ b/controllers/front/submit.php
@@ -32,6 +32,7 @@
 class PayPalSubmitModuleFrontController extends ModuleFrontController
 {
 	public $display_column_left = false;
+	public $ssl = true;
 
 	public function initContent()
 	{


### PR DESCRIPTION
[-] MO: paypal confirmation page SHOULD obey SSL settings by pretending to be an OrderConfirmationController
