### PR TITLE
Release/3.8.3

### DIFF
--- a/config.xml
+++ b/config.xml
@@ -2,7 +2,7 @@
 <module>
 	<name>paypal</name>
 	<displayName><![CDATA[PayPal]]></displayName>
-	<version><![CDATA[3.8.2]]></version>
+	<version><![CDATA[3.8.3]]></version>
 	<description><![CDATA[Accepts payments by credit cards (CB, Visa, MasterCard, Amex, Aurore, Cofinoga, 4 stars) with PayPal.]]></description>
 	<author><![CDATA[PrestaShop]]></author>
 	<tab><![CDATA[payments_gateways]]></tab>

--- a/css/paypal.css
+++ b/css/paypal.css
@@ -21,10 +21,10 @@ span.paypal-section{background:url(../img/sprites.png) no-repeat 0 0;color:#FFF!
 #paypal-call,#paypal-call-foonote{background:#e1e1e1 url(../img/bg-call-button.png) repeat-x;border:1px solid #d2d2d2;border-left-color:#ddd;border-radius:5px;border-right-color:#ddd;border-top-color:#e9e9e9;color:#369;display:block;margin:0;padding:10px 20px;width:auto}
 #paypal-call-foonote{background:none;border:none;font-size:.8em;max-width:320px;padding:2px 10px;text-align:justify}
 #paypal-get-identification{display:block;min-width:378px;text-align:center}
-#paypal-wrapper a,#fancybox-wrap a,.fancybox-wrap a{color:#036;text-decoration:underline}
-#paypal-wrapper h1,#paypal-wrapper h2,#paypal-wrapper h3,#paypal-wrapper h4,#paypal-wrapper h5,#paypal-wrapper h6,#fancybox-wrap h1,#fancybox-wrap h2,#fancybox-wrap h3,#fancybox-wrap h4,#fancybox-wrap h5,#fancybox-wrap h6,.fancybox-wrap h1,.fancybox-wrap h2,.fancybox-wrap h3,.fancybox-wrap h4,.fancybox-wrap h5,.fancybox-wrap h6{color:#036;font-family:Arial, Verdana, Helvetica, sans-serif;font-weight:400;text-transform:uppercase}
-#fancybox-wrap h3,.fancybox-wrap h3,#paypal-wrapper h3{font-size:1.4em;line-height:24px}
-#fancybox-wrap h4,.fancybox-wrap h4,#paypal-wrapper h4{font-size:1.2em;margin-bottom:5px;text-transform:none}
+#paypal-wrapper a,#paypal-test-mode-confirmation a{color:#036;text-decoration:underline}
+#paypal-wrapper h1,#paypal-wrapper h2,#paypal-wrapper h3,#paypal-wrapper h4,#paypal-wrapper h5,#paypal-wrapper h6,#paypal-country-form h1, #paypal-test-mode-confirmation h1,#paypal-country-form h2, #paypal-test-mode-confirmation h2,#paypal-country-form h3, #paypal-test-mode-confirmation h3,#paypal-country-form h4, #paypal-test-mode-confirmation h4,#paypal-country-form h5, #paypal-test-mode-confirmation h5,#paypal-country-form h6, #paypal-test-mode-confirmation h6{color:#036;font-family:Arial, Verdana, Helvetica, sans-serif;font-weight:400;text-transform:uppercase}
+#paypal-country-form h3, #paypal-test-mode-confirmation h3,#paypal-wrapper h3{font-size:1.4em;line-height:24px}
+#paypal-country-form h4, #paypal-test-mode-confirmation h4,#paypal-wrapper h4{font-size:1.2em;margin-bottom:5px;text-transform:none}
 #paypal-wrapper h1.inline + img,#paypal-wrapper h2.inline + img,#paypal-wrapper h3.inline + img,#paypal-wrapper h4.inline + img,#paypal-wrapper h5.inline + img,#paypal-wrapper h6.inline + img{vertical-align:-6px}
 #paypal-wrapper p{margin-top:10px;padding-bottom:0}
 #paypal-wrapper .form-block{margin-top:5px}
@@ -35,11 +35,11 @@ span.paypal-section{background:url(../img/sprites.png) no-repeat 0 0;color:#FFF!
 #paypal-wrapper dl dt label{margin:0;padding:0}
 #paypal-wrapper .description,#paypal-wrapper .paypal-signup-content{color:#666;font-size:.9em;font-weight:400;margin:2px 0;font-size:11px; font-style:italic;}
 label span.description{display:block;padding-left:16px}
-#paypal-wrapper input[type=submit],.fancybox-wrap button,#fancybox-wrap button,#paypal-wrapper .paypal-button{background:url(../img/bg-button.png) repeat-x;border:1px solid #f29116;border-radius:4px;color:#292929;cursor:pointer;display:inline-block;font-weight:700;height:25px;line-height:26px;padding:0 10px;text-decoration:none;text-shadow:0 1px 1px #DDD;text-transform:uppercase}
-#fancybox-wrap ul,.fancybox-wrap ul{font-size:1.1em;padding-left:10px}
-#fancybox-wrap button,.fancybox-wrap button{line-height:20px}
+#paypal-wrapper input[type=submit],#paypal-country-form button, #paypal-test-mode-confirmation button,#paypal-wrapper .paypal-button{background:url(../img/bg-button.png) repeat-x;border:1px solid #f29116;border-radius:4px;color:#292929;cursor:pointer;display:inline-block;font-weight:700;height:25px;line-height:26px;padding:0 10px;text-decoration:none;text-shadow:0 1px 1px #DDD;text-transform:uppercase}
+#paypal-country-form ul, #paypal-test-mode-confirmation ul{font-size:1.1em;padding-left:10px}
+#paypal-country-form button, #paypal-test-mode-confirmation button{line-height:20px}
 #paypal-test-mode-confirmation{margin:30px;text-align:left;width:500px}
-#fancybox-wrap #buttons,.fancybox-wrap #buttons{margin-top:20px;text-align:right}
+#paypal-country-form #buttons, paypal-test-mode-confirmation#buttons{margin-top:20px;text-align:right}
 #paypal-test-mode-confirmation button + button{margin-left:20px;margin-right:20px}
 #paypal-save-success,#paypal-save-failure{width:450px}
 #container_express_checkout{margin:auto;text-align:left}

--- a/express_checkout/ajax.php
+++ b/express_checkout/ajax.php
@@ -40,5 +40,9 @@ if ($quantity && $quantity > 0)
 	
 	if ($product_quantity > 0)
 		die('1');
+
+	if($product_quantity <= 0 && $product->isAvailableWhenOutOfStock((int)$product->out_of_stock))
+		die('1');
+
 }
 die('0');

--- a/express_checkout/ajax.php
+++ b/express_checkout/ajax.php
@@ -41,6 +41,9 @@ if ($quantity && $quantity > 0)
 	$id_product_attribute = (int)Tools::getValue('id_product_attribute');
 	$product_quantity = Product::getQuantity($id_product, $id_product_attribute);
 	$product = new Product($id_product);
+
+	if(!$product->available_for_order)
+		die('0');
 	
 	if ($product_quantity > 0)
 		die('1');

--- a/express_checkout/ajax.php
+++ b/express_checkout/ajax.php
@@ -31,12 +31,16 @@ include_once(dirname(__FILE__).'/../paypal.php');
 // Ajax query
 $quantity = Tools::getValue('get_qty');
 
+if(Configuration::get('PS_CATALOG_MODE') == 1)
+	die('0');
+
 if ($quantity && $quantity > 0)
 {
 	/* Ajax response */
 	$id_product = (int)Tools::getValue('id_product');
 	$id_product_attribute = (int)Tools::getValue('id_product_attribute');
 	$product_quantity = Product::getQuantity($id_product, $id_product_attribute);
+	$product = new Product($id_product);
 	
 	if ($product_quantity > 0)
 		die('1');

--- a/express_checkout/payment.php
+++ b/express_checkout/payment.php
@@ -244,7 +244,7 @@ function validateOrder($customer, $cart, $ppec)
 	{
 		if ((bool)Configuration::get('PAYPAL_CAPTURE'))
 		{
-			$payment_type = (int)Configuration::get('PS_OS_WS_PAYMENT');
+			$payment_type = (int)Configuration::get('PS_OS_PAYPAL');
 			$payment_status = 'Pending_capture';
 			$message = $ppec->l('Pending payment capture.').'<br />';
 		}

--- a/express_checkout/process.php
+++ b/express_checkout/process.php
@@ -365,9 +365,18 @@ class PaypalExpressCheckout extends Paypal
 		}
 		else
 		{
-			$fields['PAYMENTREQUEST_0_SHIPPINGAMT'] = sprintf('%.2f', $shipping_cost_wt);
-			$fields['PAYMENTREQUEST_0_ITEMAMT'] = Tools::ps_round($total, $this->decimals);
-			$fields['PAYMENTREQUEST_0_AMT'] = sprintf('%.2f', ($total + $fields['PAYMENTREQUEST_0_SHIPPINGAMT']));
+			if($currency->iso_code == "HUF")
+			{ 
+				$fields['PAYMENTREQUEST_0_SHIPPINGAMT'] = round($shipping_cost_wt); 
+				$fields['PAYMENTREQUEST_0_ITEMAMT'] = Tools::ps_round($total, $this->decimals); 
+				$fields['PAYMENTREQUEST_0_AMT'] = sprintf('%.2f', ($total + $fields['PAYMENTREQUEST_0_SHIPPINGAMT'])); 
+			}
+			else
+			{ 
+				$fields['PAYMENTREQUEST_0_SHIPPINGAMT'] = sprintf('%.2f', $shipping_cost_wt);
+				$fields['PAYMENTREQUEST_0_ITEMAMT'] = Tools::ps_round($total, $this->decimals);
+				$fields['PAYMENTREQUEST_0_AMT'] = sprintf('%.2f', ($total + $fields['PAYMENTREQUEST_0_SHIPPINGAMT']));
+			}
 		}
 	}
 

--- a/integral_evolution/submit.php
+++ b/integral_evolution/submit.php
@@ -37,7 +37,7 @@ class PayPalIntegralEvolutionSubmit extends OrderConfirmationControllerCore
 	public function __construct()
 	{
 		/** Backward compatibility */
-		include_once(_PS_MODULE_DIR_.'/paypal/backward_compatibility/backward.php');
+		include_once(_PS_MODULE_DIR_.'paypal/backward_compatibility/backward.php');
 		$this->context = Context::getContext();
 		parent::__construct();
 	}
@@ -62,7 +62,7 @@ class PayPalIntegralEvolutionSubmit extends OrderConfirmationControllerCore
 			));
 		}
 
-		echo $this->context->smarty->fetch(_PS_MODULE_DIR_.'/paypal/views/templates/front/order-confirmation.tpl');
+		echo $this->context->smarty->fetch(_PS_MODULE_DIR_.'paypal/views/templates/front/order-confirmation.tpl');
 	}
 }
 

--- a/js/paypal.js
+++ b/js/paypal.js
@@ -60,12 +60,15 @@ $(document).ready( function() {
 	}
 
 	$('select[name^="group_"]').change(function () {
-		displayExpressCheckoutShortcut();
+		setTimeout(function(){displayExpressCheckoutShortcut()}, 500);
 	});
 
 	$('.color_pick').click(function () {
-		displayExpressCheckoutShortcut();
+		setTimeout(function(){displayExpressCheckoutShortcut()}, 500);
 	});
+
+	if($('body#product').length > 0)
+		setTimeout(function(){displayExpressCheckoutShortcut()}, 500);
 	
 	{/literal}
 	{if isset($paypal_authorization)}

--- a/js/paypal.js
+++ b/js/paypal.js
@@ -131,7 +131,7 @@ $(document).ready( function() {
 	var subFolder = '/integral_evolution';
 	{/literal}
 	{if $ssl_enabled}
-		var baseDirPP = baseDir.replace('http', 'https');
+		var baseDirPP = baseDir.replace('http:', 'https:');
 	{else}
 		var baseDirPP = baseDir;
 	{/if}

--- a/paypal.php
+++ b/paypal.php
@@ -1528,7 +1528,7 @@ class PayPal extends PaymentModule
 				}
 
 				// calculate the longest length of decimals
-				$dLen = max(Tools::strlen($dec1), Tools::strlen($dec2));
+				$d_len = max(Tools::strlen($dec1), Tools::strlen($dec2));
 
 				// append the padded decimals onto the end of the whole numbers
 				$num1 .= str_pad($dec1, $d_len, '0');

--- a/paypal.php
+++ b/paypal.php
@@ -160,7 +160,7 @@ class PayPal extends PaymentModule
 	public function runUpgrades($install = false)
 	{
 		if (version_compare(_PS_VERSION_, '1.5', '<'))
-			foreach (array('2.8', '3.0', '3.7') as $version)
+			foreach (array('2.8', '3.0', '3.7', '3.8.3') as $version)
 			{
 				$file = dirname(__FILE__).'/upgrade/install-'.$version.'.php';
 				if (Configuration::get('PAYPAL_VERSION') < $version && file_exists($file))

--- a/paypal.php
+++ b/paypal.php
@@ -434,7 +434,7 @@ class PayPal extends PaymentModule
 			case 'id':
 				return 'id-id';
 			case 'il':
-				return 'it-il';
+				return 'it-it';
 			case 'jp':
 				return 'ja-jp';
 			case 'no':

--- a/paypal.php
+++ b/paypal.php
@@ -83,7 +83,7 @@ class PayPal extends PaymentModule
 	{
 		$this->name = 'paypal';
 		$this->tab = 'payments_gateways';
-		$this->version = '3.8.2';
+		$this->version = '3.8.3';
 		$this->author = 'PrestaShop';
 		$this->is_eu_compatible = 1;
 

--- a/paypal.php
+++ b/paypal.php
@@ -828,13 +828,18 @@ class PayPal extends PaymentModule
 			elseif (_PS_MOBILE_PHONE_)
 				return SMARTPHONE_TRACKING_CODE;
 		}
-
 		//Get Seamless checkout
-		$login_user = PaypalLoginUser::getByIdCustomer((int)$this->context->customer->id);
-		if ($login_user && $login_user->expires_in <= time())
+		
+		$login_user = false;
+		if(Configuration::get('PAYPAL_LOGIN'))
 		{
-			$obj = new PayPalLogin();
-			$login_user = $obj->getRefreshToken();
+			$login_user = PaypalLoginUser::getByIdCustomer((int)$this->context->customer->id);
+
+			if ($login_user && $login_user->expires_in <= time())
+			{
+				$obj = new PayPalLogin();
+				$login_user = $obj->getRefreshToken();
+			}
 		}
 
 		if ($method == WPS)

--- a/paypal.php
+++ b/paypal.php
@@ -716,7 +716,7 @@ class PayPal extends PaymentModule
 
 	public function hookCancelProduct($params)
 	{
-		if (Tools::isSubmit('generateDiscount') || !$this->isPayPalAPIAvailable())
+		if (Tools::isSubmit('generateDiscount') || !$this->isPayPalAPIAvailable() || Tools::isSubmit('generateCreditSlip'))
 			return false;
 		elseif ($params['order']->module != $this->name || !($order = $params['order']) || !Validate::isLoadedObject($order))
 			return false;

--- a/paypal.php
+++ b/paypal.php
@@ -27,12 +27,12 @@
 if (!defined('_PS_VERSION_'))
 	exit;
 
-include_once(_PS_MODULE_DIR_.'/paypal/api/paypal_lib.php');
-include_once(_PS_MODULE_DIR_.'/paypal/paypal_logos.php');
-include_once(_PS_MODULE_DIR_.'/paypal/paypal_orders.php');
-include_once(_PS_MODULE_DIR_.'/paypal/paypal_tools.php');
-include_once(_PS_MODULE_DIR_.'/paypal/paypal_login/paypal_login.php');
-include_once(_PS_MODULE_DIR_.'/paypal/paypal_login/PayPalLoginUser.php');
+include_once(_PS_MODULE_DIR_.'paypal/api/paypal_lib.php');
+include_once(_PS_MODULE_DIR_.'paypal/paypal_logos.php');
+include_once(_PS_MODULE_DIR_.'paypal/paypal_orders.php');
+include_once(_PS_MODULE_DIR_.'paypal/paypal_tools.php');
+include_once(_PS_MODULE_DIR_.'paypal/paypal_login/paypal_login.php');
+include_once(_PS_MODULE_DIR_.'paypal/paypal_login/PayPalLoginUser.php');
 
 define('WPS', 1); //Paypal Integral
 define('HSS', 2); //Paypal Integral Evolution
@@ -131,7 +131,7 @@ class PayPal extends PaymentModule
 		!$this->registerHook('displayMobileShoppingCartTop') || !$this->registerHook('displayMobileAddToCartTop')))
 			return false;
 
-		include_once(_PS_MODULE_DIR_.'/'.$this->name.'/paypal_install.php');
+		include_once(_PS_MODULE_DIR_.$this->name.'/paypal_install.php');
 		$paypal_install = new PayPalInstall();
 		$paypal_install->createTables();
 		$paypal_install->updateConfiguration($this->version);
@@ -148,7 +148,7 @@ class PayPal extends PaymentModule
 
 	public function uninstall()
 	{
-		include_once(_PS_MODULE_DIR_.'/'.$this->name.'/paypal_install.php');
+		include_once(_PS_MODULE_DIR_.$this->name.'/paypal_install.php');
 		$paypal_install = new PayPalInstall();
 		$paypal_install->deleteConfiguration();
 		return parent::uninstall();
@@ -173,7 +173,7 @@ class PayPal extends PaymentModule
 
 	private function compatibilityCheck()
 	{
-		if (file_exists(_PS_MODULE_DIR_.'/paypalapi/paypalapi.php') && $this->active)
+		if (file_exists(_PS_MODULE_DIR_.'paypalapi/paypalapi.php') && $this->active)
 			$this->warning = $this->l('All features of Paypal API module are included in the new Paypal module. In order to do not have any conflict, please do not use and remove PayPalAPI module.').'<br />';
 
 		/* For 1.4.3 and less compatibility */

--- a/upgrade/install-3.0.php
+++ b/upgrade/install-3.0.php
@@ -79,5 +79,15 @@ function upgrade_module_3_0($object, $install = false)
 			) ENGINE='._MYSQL_ENGINE_.' DEFAULT CHARSET=utf8 AUTO_INCREMENT=1');
 	}
 
+	//Add datas to paypal order
+	Db::getInstance()->Execute('
+		ALTER TABLE `' . _DB_PREFIX_ . 'paypal_order`
+		ADD `id_invoice` varchar(255) DEFAULT NULL,
+		ADD `currency` varchar(10) NOT NULL,
+		ADD `total_paid` varchar(50) NOT NULL,				
+		ADD `shipping` varchar(50) NOT NULL,
+		ADD `payment_date` varchar(50) NOT NULL,	
+	');
+
 	return true;
 }

--- a/upgrade/install-3.0.php
+++ b/upgrade/install-3.0.php
@@ -78,16 +78,5 @@ function upgrade_module_3_0($object, $install = false)
 				PRIMARY KEY (`id_paypal_customer`)
 			) ENGINE='._MYSQL_ENGINE_.' DEFAULT CHARSET=utf8 AUTO_INCREMENT=1');
 	}
-
-	//Add datas to paypal order
-	Db::getInstance()->Execute('
-		ALTER TABLE `' . _DB_PREFIX_ . 'paypal_order`
-		ADD `id_invoice` varchar(255) DEFAULT NULL,
-		ADD `currency` varchar(10) NOT NULL,
-		ADD `total_paid` varchar(50) NOT NULL,				
-		ADD `shipping` varchar(50) NOT NULL,
-		ADD `payment_date` varchar(50) NOT NULL,	
-	');
-
 	return true;
 }

--- a/upgrade/install-3.8.3.php
+++ b/upgrade/install-3.8.3.php
@@ -1,0 +1,53 @@
+<?php
+/*
+* 2007-2014 PrestaShop
+*
+* NOTICE OF LICENSE
+*
+* This source file is subject to the Academic Free License (AFL 3.0)
+* that is bundled with this package in the file LICENSE.txt.
+* It is also available through the world-wide-web at this URL:
+* http://opensource.org/licenses/afl-3.0.php
+* If you did not receive a copy of the license and are unable to
+* obtain it through the world-wide-web, please send an email
+* to license@prestashop.com so we can send you a copy immediately.
+*
+* DISCLAIMER
+*
+* Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+* versions in the future. If you wish to customize PrestaShop for your
+* needs please refer to http://www.prestashop.com for more information.
+*
+*  @author PrestaShop SA <contact@prestashop.com>
+*  @copyright  2007-2014 PrestaShop SA
+*  @license    http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
+*  International Registered Trademark & Property of PrestaShop SA
+*/
+
+if (!defined('_PS_VERSION_'))
+	exit;
+
+function upgrade_module_3_8_3($object, $install = false)
+{
+	$paypal_version = Configuration::get('PAYPAL_VERSION');
+
+	if ((!$paypal_version) || (empty($paypal_version)) || ($paypal_version < $object->version))
+	{
+		if (Db::getInstance()->ExecuteS('SHOW COLUMNS FROM `'._DB_PREFIX_.'paypal_order` LIKE \'id_invoice\'') == false)
+			Db::getInstance()->Execute('ALTER TABLE `'._DB_PREFIX_.'paypal_order` ADD `id_invoice` varchar(255) DEFAULT NULL');
+		if (Db::getInstance()->ExecuteS('SHOW COLUMNS FROM `'._DB_PREFIX_.'paypal_order` LIKE \'currency\'') == false)
+			Db::getInstance()->Execute('ALTER TABLE `'._DB_PREFIX_.'paypal_order` ADD `currency` varchar(10) DEFAULT NULL');
+		if (Db::getInstance()->ExecuteS('SHOW COLUMNS FROM `'._DB_PREFIX_.'paypal_order` LIKE \'total_paid\'') == false)
+			Db::getInstance()->Execute('ALTER TABLE `'._DB_PREFIX_.'paypal_order` ADD `total_paid` varchar(50) DEFAULT NULL');
+		if (Db::getInstance()->ExecuteS('SHOW COLUMNS FROM `'._DB_PREFIX_.'paypal_order` LIKE \'shipping\'') == false)
+			Db::getInstance()->Execute('ALTER TABLE `'._DB_PREFIX_.'paypal_order` ADD `shipping` varchar(50) DEFAULT NULL');
+		if (Db::getInstance()->ExecuteS('SHOW COLUMNS FROM `'._DB_PREFIX_.'paypal_order` LIKE \'payment_date\'') == false)
+			Db::getInstance()->Execute('ALTER TABLE `'._DB_PREFIX_.'paypal_order` ADD `shipping` payment_date(50) DEFAULT NULL');
+
+
+		Configuration::updateValue('PAYPAL_VERSION', '3.8.3');
+	}
+
+
+	return true;
+}


### PR DESCRIPTION
Release containing different fixes

Partial refund 
fix : Product return creates a refund
Fancybox overrides front office behavior
Completed_Funds_Held on return from paypal
Hungarian Forain needs 0 decimals
After capture, change order state
Fix on stock quantities on PS 1.6 when changing an attribute
Fix on javascript link when using https replacement 
PayPal on Mobile theme of Ps 1.5 shows button when product not in stock
Fixed lang send to paypal when coming from italy : it-il => it-it
When a product is Out Of stock or not available for sale paypal button is still available
