### PR TITLE
[-] MO - paypal : Fix issue #7 'Paypal currency conversion not working'

### DIFF
--- a/express_checkout/process.php
+++ b/express_checkout/process.php
@@ -127,7 +127,7 @@ class PaypalExpressCheckout extends Paypal
 		}
 
 		$this->context->currency = $currency_module;
-		$this->product_list = $this->context->cart->getProducts();
+		$this->product_list = $this->context->cart->getProducts(true);
 		return (bool)count($this->product_list);
 	}
 


### PR DESCRIPTION
The problem occurs because the caching [`$this->_products`](https://github.com/PrestaShop/PrestaShop/blob/develop/classes/Cart.php#L492) if in the hook '[actionCartSave](https://github.com/PrestaShop/PrestaShop/blob/develop/classes/Cart.php#L214)' someone (for example Google Analytics module) will run method `context->cart->getProducts()`
