### PR TITLE
broke ssl in admin order page

### DIFF
--- a/paypal.php
+++ b/paypal.php
@@ -741,7 +741,7 @@ class PayPal extends PaymentModule
 			$this->context->smarty->assign(
 				array(
 					'authorization' => (int)Configuration::get('PAYPAL_OS_AUTHORIZATION'),
-					'base_url' => _PS_BASE_URL_.__PS_BASE_URI__,
+					'base_url' => Tools::getHttpHost(true).__PS_BASE_URI__,
 					'module_name' => $this->name,
 					'order_state' => $order_state,
 					'params' => $params,


### PR DESCRIPTION
in admin order page

line 744:
`'base_url' => _PS_BASE_URL_.__PS_BASE_URI__,` -> broke ssl mixed: mixed content -> ...but requested an insecure image 'http://www.xxx.com/modules/paypal/logo.gif'. This content should also be served over HTTPS.

solved with: `'base_url' => Tools::getHttpHost(true).__PS_BASE_URI__,`
