### PR TITLE
fix smarty template error in order-confirmation-mobile.tpl

### DIFF
--- a/views/templates/front/order-confirmation-mobile.tpl
+++ b/views/templates/front/order-confirmation-mobile.tpl
@@ -61,7 +61,7 @@
 				<a href="{$link->getPageLink('index', true)|escape:'htmlall':'UTF-8'}" data-ajax="false">{l s='Continue shopping' mod='paypal'}</a>
 			</li>
 			<li data-theme="b" data-icon="back">
-				<a href="{$link->getPageLink('history.php', true, NULL, 'step=1&amp;back={$back|escape:'htmlall':'UTF-8'}')}" data-ajax="false">{l s='Back to orders' mod='paypal'}</a>
+				<a href="{$link->getPageLink('history.php', true)|escape:'htmlall':'UTF-8'}" title="{l s='Back to orders' mod='paypal'}" data-ajax="false">{l s='Back to orders' mod='paypal'}</a>
 			</li>
 		</ul>
 	{/if}


### PR DESCRIPTION
order-confirmation-mobile.tpl caused an smarty compile error. This commit fixes the error. Changed the link according to the other order confirmation templates.

PHP Fatal error:  Uncaught  --> Smarty Compiler: Syntax error in template "/var/www/vhosts/example.org/httpdocs/modules/paypal/views/templates/front/order-confirmation-mobile.tpl"  on line 64 "<a href="{$link->getPageLink('history.php', true, NULL, 'step=1&amp;back={$back|escape:'htmlall':'UTF-8'}')}" data-ajax="false">{l s='Back to orders' mod='paypal'}</a>"  - Unexpected "htmlall", expected one of: "","" , ")" <-- \n  thrown in /var/www/vhosts/example.org/httpdocs/tools/smarty/sysplugins/smarty_internal_templatecompilerbase.php on line 64\n', referer: https://www.paypal.com/cgi-bin/webscr?cmd=_express-checkout-mobile&useraction=commit&token=MYSECURETOKEN
