### PR TITLE
[*] MO - paypal : fix mobile confirmation tpl fatal error

### DIFF
--- a/views/templates/front/order-confirmation-mobile.tpl
+++ b/views/templates/front/order-confirmation-mobile.tpl
@@ -61,7 +61,7 @@
 				<a href="{$link->getPageLink('index', true)|escape:'htmlall':'UTF-8'}" data-ajax="false">{l s='Continue shopping' mod='paypal'}</a>
 			</li>
 			<li data-theme="b" data-icon="back">
-				<a href="{$link->getPageLink('history.php', true, NULL, 'step=1&amp;back={$back|escape:'htmlall':'UTF-8'}')}" data-ajax="false">{l s='Back to orders' mod='paypal'}</a>
+				<a href="{$link->getPageLink('history.php', true, NULL, 'step=1&amp;back={$back}')|escape:'htmlall':'UTF-8'}" data-ajax="false">{l s='Back to orders' mod='paypal'}</a>
 			</li>
 		</ul>
 	{/if}


### PR DESCRIPTION
PHP Fatal error:  Uncaught  --> Smarty Compiler: Syntax error in template ".../modules/paypal/views/templates/front/order-confirmation-mobile.tpl"  on line 64 "<a href="{$link->getPageLink('history.php', true, NULL, 'step=1&amp;back={$back|escape:'htmlall':'UTF-8'}')}" data-ajax="false">{l s='Back to orders' mod='paypal'}</a>"  - Unexpected "htmlall", expected one of: "","" , ")"
