### PR TITLE
[*] MO - paypal : use_paypal_in_context is not set when disabled

### DIFF
--- a/views/templates/hook/express_checkout_shortcut_form.tpl
+++ b/views/templates/hook/express_checkout_shortcut_form.tpl
@@ -41,7 +41,7 @@
 	<input type="hidden" name="bn" value="{$PayPal_tracking_code|escape:'htmlall':'UTF-8'}" />
 </form>
 
-{if $use_paypal_in_context}
+{if isset($use_paypal_in_context) && $use_paypal_in_context}
 	<input type="hidden" id="in_context_checkout_enabled" value="1">
 {else}
 	<input type="hidden" id="in_context_checkout_enabled" value="0">


### PR DESCRIPTION
Avoid tons of PHP warnings in logs:

PHP Notice:  Undefined index: use_paypal_in_context in .../cache/smarty/compile/e5/73/f6/e573f645d1e079907ea34d537e97c6a104cccfed.file.express_checkout_shortcut_form.tpl.php on line 60
