### PR TITLE
Manage URI with port for Cancel URL

### DIFF
--- a/express_checkout/process.php
+++ b/express_checkout/process.php
@@ -172,6 +172,9 @@ class PaypalExpressCheckout extends Paypal
         $parsed_data = parse_url($url);
 
         $parsed_data['scheme'] .= '://';
+        if (isset($parsed_data['port'])) {
+            $parsed_data['port'] = ':' . $parsed_data['port'];
+        }
 
         if (isset($parsed_data['path'])) {
             $parsed_data['path'] .= '?paypal_ec_canceled=1&';


### PR DESCRIPTION
To avoid `https://localhost:4000` to be wrongly replaced by `https://localhost4000` in `current_shop_url`.